### PR TITLE
Change numpy.int64 to python int for cuda mem allocation sizes

### DIFF
--- a/warpDrive/buffers.py
+++ b/warpDrive/buffers.py
@@ -34,6 +34,8 @@ class Buffer(to_subclass):
 
         #---- allocate memory
         pix_r, pix_c = self.slice_shape
+        pix_r = int(pix_r)  # use python dtypes instead of numpy int types
+        pix_c = int(pix_c)
         self.cur_bg = np.empty((pix_r, pix_c), np.float32)
         self.cur_bg_gpu = cuda.mem_alloc(pix_r * pix_c * self.cur_bg.dtype.itemsize)
 

--- a/warpDrive/buffers.py
+++ b/warpDrive/buffers.py
@@ -30,12 +30,11 @@ class Buffer(to_subclass):
         self.cur_positions = {}
         self.available = list(range(buffer_length))
 
-        self.slice_shape = self.data_buffer.dataSource.getSliceShape()
+        # cuda.mem_alloc expects python int; avoid potential np.int64
+        self.slice_shape = [int(d) for d in self.data_buffer.dataSource.getSliceShape()]
 
         #---- allocate memory
         pix_r, pix_c = self.slice_shape
-        pix_r = int(pix_r)  # use python dtypes instead of numpy int types
-        pix_c = int(pix_c)
         self.cur_bg = np.empty((pix_r, pix_c), np.float32)
         self.cur_bg_gpu = cuda.mem_alloc(pix_r * pix_c * self.cur_bg.dtype.itemsize)
 

--- a/warpDrive/detector.py
+++ b/warpDrive/detector.py
@@ -188,7 +188,7 @@ class detector(object):
         longer compatible.
         """
 
-        self.varmap = varmap / (electronsPerCount ** 2)  # [e-^2] -> [ADU^2]
+        self.varmap = varmap
 
         # note that PYME-style flatmaps are unitless, need to convert to gain in units of [ADU/e-]
         cuda.memcpy_htod_async(self.gain_gpu,

--- a/warpDrive/detector.py
+++ b/warpDrive/detector.py
@@ -101,8 +101,8 @@ class detector(object):
         Allocate memory on the GPU. These allocations will be held until the detector object is destroyed.
         """
 
-        self.dshape = dshape
-        self.dsize = dshape[0] * dshape[1] * ditemsize
+        self.dshape = [int(d) for d in dshape]  # use numpy int type for sizes; avoid potential np.int64
+        self.dsize = dshape[0] * dshape[1] * int(ditemsize)
 
         self.rowsize = np.int32(self.dshape[0])  # integers must be passed to PyCUDA functions as int32's
         self.colsize = np.int32(self.dshape[1])


### PR DESCRIPTION
Using numpy.int64 in memory allocations with libboost-dev 1.58.0.1, and
```(py36) smeagol@smeagol:~/code/pyme-warp-drive$ conda list | grep pycuda
pycuda                    2019.1.2                  <pip>
(py36) smeagol@smeagol:~/code/pyme-warp-drive$ conda list | grep numpy
numpy                     1.16.3           py36h7e9f1db_0  
numpy-base                1.16.3           py36hde5b4d6_0  
(py36) smeagol@smeagol:~/code/pyme-warp-drive$ nvcc --version
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2017 NVIDIA Corporation
Built on Fri_Sep__1_21:08:03_CDT_2017
Cuda compilation tools, release 9.0, V9.0.176
```
yields errors like the following
```
Traceback (most recent call last):
  File "/home/smeagol/code/python-microscopy/PYME/DSView/modules/LMAnalysis.py", line 277, in <lambda>
    bTestF.Bind(wx.EVT_BUTTON, lambda e : self.lmanal.OnTestFrame(e))
  File "/home/smeagol/code/python-microscopy/PYME/DSView/modules/LMAnalysis.py", line 627, in OnTestFrame
    ft, fr = self.testFrame()
  File "/home/smeagol/code/python-microscopy/PYME/DSView/modules/LMAnalysis.py", line 878, in testFrame
    res = ft(gui=gui,taskQueue=self.tq)
  File "/home/smeagol/code/python-microscopy/PYME/localization/remFitBuf.py", line 433, in __call__
    bufferManager.bBuffer.calc_background(self.bgindices)
  File "/home/smeagol/code/pyme-warp-drive/warpDrive/buffers.py", line 201, in calc_background
    self.update_buffer(bg_indices)
  File "/home/smeagol/code/pyme-warp-drive/warpDrive/buffers.py", line 175, in update_buffer
    self.update(frame, position, frame_data)
  File "/home/smeagol/code/pyme-warp-drive/warpDrive/buffers.py", line 112, in update
    block=(self.slice_shape[0], 1, 1), grid=(self.slice_shape[1], 1), stream=self.bg_streamer)
  File "/home/smeagol/anaconda2/envs/py36/lib/python3.6/site-packages/pycuda/driver.py", line 436, in function_call
    func._set_block_shape(*block)
Boost.Python.ArgumentError: Python argument types in
    Function._set_block_shape(Function, numpy.int64, int, int)
did not match C++ signature:
    _set_block_shape(pycuda::function {lvalue}, int, int, int)
```

